### PR TITLE
Amend recommendations for working with Array, Object, and String literals

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -520,7 +520,7 @@ var c = [
   'per line'
 ];
 var d = ['however', 'it', 'is', 'okay', 'if', 'you', 'have', 'just', 'a', 'few',
-    'overflow'];
+  'overflow'];
 ```
 
 *Wrong:*
@@ -546,11 +546,11 @@ of the code, make sure to break into multiple lines using string concatenation.
 
 ```js
 var myString = 'A rather long string of English text, an error message ' +
-    'actually that just keeps going and going -- an error ' +
-    'message to make the Energizer bunny blush (right through ' +
-    'those Schwarzenegger shades)! Where was I? Oh yes, ' +
-    'you\'ve got an error and all the extraneous whitespace is ' +
-    'just gravy.  Have a nice day.';
+  'actually that just keeps going and going -- an error ' +
+  'message to make the Energizer bunny blush (right through ' +
+  'those Schwarzenegger shades)! Where was I? Oh yes, ' +
+  'you\'ve got an error and all the extraneous whitespace is ' +
+  'just gravy.  Have a nice day.';
 ```
 
 *Wrong:*

--- a/Readme.md
+++ b/Readme.md
@@ -477,6 +477,79 @@ setTimeout(function() {
 }, 1000);
 ```
 
+## Do not use associative Array
+
+Never use `Array` as a map/hash/associative array; more precisely you are not
+allowed to use non number indexes for `Array` types. If you need a map/hash use
+`Object` instead of `Array` in these cases because the features that you want
+are actually features of `Object` and not of `Array`. `Array` just happens to
+extend `Object` (like any other object in JS and therefore you might as well
+have used `Date`, `RegExp` or `String`).
+
+*Right:*
+
+```js
+var arr = [1, 2, 3];
+var obj = {};
+
+obj['a'] = 'value';
+obj[1] = 'value';
+```
+
+*Wrong:*
+
+```js
+var arr = [];
+arr['0'] = 3;
+arr.a = 'value';
+```
+
+## Array and Object literals
+
+Initialize `Array` and `Object` literals with `[]` and `{}` rather than the
+constructor.
+
+*Right:*
+
+```js
+var myArray = [];
+var myObject = {};
+```
+
+*Wrong:*
+
+```js
+var myArray = new Array();
+var myObject = new Object();
+```
+
+## Multi-line string literals
+
+When a string literal grows to long, or when you are drafting a paragraph inside
+of the code, make sure to break into multiple lines using string concatenation.
+
+*Right:*
+
+```js
+var myString = 'A rather long string of English text, an error message ' +
+    'actually that just keeps going and going -- an error ' +
+    'message to make the Energizer bunny blush (right through ' +
+    'those Schwarzenegger shades)! Where was I? Oh yes, ' +
+    'you\'ve got an error and all the extraneous whitespace is ' +
+    'just gravy.  Have a nice day.';
+```
+
+*Wrong:*
+
+```js
+var myString = 'A rather long string of English text, an error message \
+                actually that just keeps going and going -- an error \
+                message to make the Energizer bunny blush (right through \
+                those Schwarzenegger shades)! Where was I? Oh yes, \
+                you\'ve got an error and all the extraneous whitespace is \
+                just gravy.  Have a nice day.';
+```
+
 ## Use slashes for comments
 
 Use slashes for both single line and multi line comments. Try to write

--- a/Readme.md
+++ b/Readme.md
@@ -33,9 +33,11 @@ according to your preferences.
 * [Use lowerCamelCase for variables, properties and function names](#use-lowercamelcase-for-variables-properties-and-function-names)
 * [Use UpperCamelCase for class names](#use-uppercamelcase-for-class-names)
 * [Use UPPERCASE for Constants](#use-uppercase-for-constants)
-* [Object / Array creation](#object--array-creation)
 * [Use the === operator](#use-the--operator)
 * [Use multi-line ternary operator](#use-multi-line-ternary-operator)
+* [Do not use associative Array](#do-not-use-associative-array)
+* [Array and Object literals](#array-and-object-literals)
+* [Multi-line string literals](#multi-line-string-literals)
 * [Use slashes for comments](#use-slashes-for-comments)
 * [Object.freeze, Object.preventExtensions, Object.seal, with, eval](#objectfreeze-objectpreventextensions-objectseal-with-eval)
 * [Getters and setters](#getters-and-setters)
@@ -257,32 +259,6 @@ File.fullPermissions = 0777;
 ```
 
 [const]: https://developer.mozilla.org/en/JavaScript/Reference/Statements/const
-
-## Object / Array creation
-
-Use trailing commas and put *short* declarations on a single line. Only quote
-keys when your interpreter complains:
-
-*Right:*
-
-```js
-var a = ['hello', 'world'];
-var b = {
-  good: 'code',
-  'is generally': 'pretty',
-};
-```
-
-*Wrong:*
-
-```js
-var a = [
-  'hello', 'world'
-];
-var b = {"good": 'code'
-        , is generally: 'pretty'
-        };
-```
 
 ## Use the === operator
 
@@ -521,6 +497,44 @@ var myObject = {};
 ```js
 var myArray = new Array();
 var myObject = new Object();
+```
+
+Use trailing commas and put *short* declarations on a single line. Only quote
+keys when your interpreter complains:
+
+*Right:*
+
+```js
+var a = ['hello', 'world'];
+var b = {
+  good: 'code',
+  'is generally': 'pretty',
+};
+var c = [
+  'when there are',
+  'a lot of items',
+  'it is',
+  'a good idea',
+  'to keep',
+  'one item',
+  'per line'
+];
+var d = ['however', 'it', 'is', 'okay', 'if', 'you', 'have', 'just', 'a', 'few',
+    'overflow'];
+```
+
+*Wrong:*
+
+```js
+var a = [
+  'hello', 'world'
+];
+var b = {"good": 'code'
+        , is generally: 'pretty'
+        };
+var c = [
+  'but', 'never',
+  'mix up'];
 ```
 
 ## Multi-line string literals


### PR DESCRIPTION
Adding sections to explain what to do with `Array`, `Object`, and `String` literals:
- Never use non-number indices for `Array` types.
- Always use Array and Object literals rather than their respective constructor.
- A word on creating multi-line Strings literals.
